### PR TITLE
Fallback on UTF-8 if we cannot open file in UTF-16

### DIFF
--- a/rubustrings
+++ b/rubustrings
@@ -14,7 +14,13 @@
 end
 
 def open_and_read_file(file_name)
-  File.open(file_name, 'rb:utf-16:utf-8').read if File.exist?(file_name)
+  return nil unless File.exist?(file_name)
+
+  begin
+    File.open(file_name, 'rb:utf-16:utf-8').read
+  rescue
+    File.open(file_name, 'r').read
+  end
 end
 
 def remove_comments_and_empty_lines(file_data)

--- a/rubustrings
+++ b/rubustrings
@@ -19,7 +19,7 @@ def open_and_read_file(file_name)
   begin
     File.open(file_name, 'rb:utf-16:utf-8').read
   rescue
-    File.open(file_name, 'r').read
+    File.open(file_name, 'rb:utf-8:utf-8').read
   end
 end
 


### PR DESCRIPTION
Support UTF-8 in addition to UTF-16. Apple documentation suggests UTF-16 is preferred for strings files, but I know a lot of projects use UTF-8 (including Apple's own ResearchKit)
