### PR TITLE
Ignore comment lines.

### DIFF
--- a/lib/rubustrings/action.rb
+++ b/lib/rubustrings/action.rb
@@ -154,6 +154,10 @@ module Rubustrings
       line_number = numbered_line_match[1]
       line = numbered_line_match[2]
 
+      # skip # character, single line and multi line comments.
+      comments_regex = /(?:#[^\n]*|\/\/[^\n]*|\/\*(?:(?!\*\/).)*\*\/)/
+      return true if comments_regex.match line
+      
       match = validate_format line
       return log_output(:error, file_name, line_number, "invalid format: #{line}") unless match
 


### PR DESCRIPTION
Maybe we should allow comments in `.strings` file.

This PR will ignore single-line, multi-line, and `#` character comment lines.